### PR TITLE
Patch for AbstractToken::getIndentation

### DIFF
--- a/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
+++ b/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
@@ -214,8 +214,7 @@ abstract class AbstractToken
     public function getIndentation()
     {
         $indentation = $this->getLineIndentation();
-
-        return $indentation.str_repeat(' ', $this->getStartColumn() - strlen($indentation));
+        return $indentation . str_repeat(' ', abs($this->getStartColumn() - strlen($indentation)));
     }
 
     public function getStartColumn()

--- a/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
+++ b/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
@@ -215,7 +215,7 @@ abstract class AbstractToken
     {
         $indentation = $this->getLineIndentation();
 
-        if($this->isFirstTokenOnLine() AND $this->matches(T_WHITESPACE)) {
+        if($this->isFirstTokenOnLine() && $this->matches(T_WHITESPACE)) {
             $indentation = '';
         }
 

--- a/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
+++ b/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
@@ -219,7 +219,7 @@ abstract class AbstractToken
             $indentation = '';
         }
 
-        return $indentation . str_repeat(' ', abs($this->getStartColumn() - strlen($indentation)));
+        return $indentation . str_repeat(' ', $this->getStartColumn() - strlen($indentation));
     }
 
     public function getStartColumn()

--- a/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
+++ b/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
@@ -214,6 +214,7 @@ abstract class AbstractToken
     public function getIndentation()
     {
         $indentation = $this->getLineIndentation();
+
         return $indentation . str_repeat(' ', abs($this->getStartColumn() - strlen($indentation)));
     }
 

--- a/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
+++ b/src/JMS/PhpManipulator/TokenStream/AbstractToken.php
@@ -215,6 +215,10 @@ abstract class AbstractToken
     {
         $indentation = $this->getLineIndentation();
 
+        if($this->isFirstTokenOnLine() AND $this->matches(T_WHITESPACE)) {
+            $indentation = '';
+        }
+
         return $indentation . str_repeat(' ', abs($this->getStartColumn() - strlen($indentation)));
     }
 

--- a/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
+++ b/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
@@ -67,27 +67,35 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider whitespaceConfigurationProvider
+     * @dataProvider indentationConfigurationProvider
      */
-    public function testGetWhitespace($flag)
+    public function testGetIndentation($flag, $lineIndentation, $indentation)
     {
         $this->stream->setIgnoreWhitespace($flag);
         $this->setCode("<?php \n  echo     'foobar';\n        exit;");
+        $i = 0;
         while ($this->stream->moveNext()) {
             if( !$this->stream->token instanceof MarkerToken ) {
-                $this->assertEmpty(trim($this->stream->token->getIndentation()));
-                $this->assertEmpty(trim($this->stream->token->getLineIndentation()));
-                $this->assertEmpty(trim($this->stream->token->getWhitespaceBefore()));
-                $this->assertEmpty(trim($this->stream->token->getWhitespaceAfter()));
+                $this->assertEquals($lineIndentation[$i], strlen($this->stream->token->getLineIndentation()));
+                $this->assertEquals($indentation[$i]    , strlen($this->stream->token->getIndentation()));
+                $i++;
             }
         }
     }
 
-    public function whitespaceConfigurationProvider()
+    public function indentationConfigurationProvider()
     {
         return array(
-            array(true ),
-            array(false)
+            array(
+                true,
+                array(0, 0, 0, 0, 0, 0),
+                array(0, 0, 4, 12, 0, 4)
+            ),
+            array(
+                false,
+                array(0, 0, 2, 2, 2, 2, 2, 2, 8, 8, 8),
+                array(0, 5, 0, 2, 6, 11, 19, 20, 0, 8, 12)
+            )
         );
     }
 

--- a/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
+++ b/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
@@ -85,10 +85,10 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
 
     public function whitespaceConfigurationProvider()
     {
-        return [
-            [true ],
-            [false]
-        ];
+        return array(
+            array(true ),
+            array(false)
+        );
     }
 
     public function testGetLineContent()

--- a/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
+++ b/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
@@ -5,6 +5,7 @@ namespace JMS\PhpManipulator\Tests;
 use JMS\PhpManipulator\TokenStream;
 use JMS\PhpManipulator\TokenStream\LiteralToken;
 use JMS\PhpManipulator\TokenStream\PhpToken;
+use JMS\PhpManipulator\TokenStream\MarkerToken;
 
 class TokenStreamTest extends \PHPUnit_Framework_TestCase
 {
@@ -63,6 +64,31 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
             'PhpToken(T_WHITESPACE, "    ", 3)',
             'MarkerToken(id = $)',
         ));
+    }
+
+    /**
+     * @dataProvider whitespaceConfigurationProvider
+     */
+    public function testGetWhitespace($flag)
+    {
+        $this->stream->setIgnoreWhitespace($flag);
+        $this->setCode("<?php \n  echo     'foobar';\n        exit;");
+        while ($this->stream->moveNext()) {
+            if( !$this->stream->token instanceof MarkerToken ) {
+                $this->assertEmpty(trim($this->stream->token->getIndentation()));
+                $this->assertEmpty(trim($this->stream->token->getLineIndentation()));
+                $this->assertEmpty(trim($this->stream->token->getWhitespaceBefore()));
+                $this->assertEmpty(trim($this->stream->token->getWhitespaceAfter()));
+            }
+        }
+    }
+
+    public function whitespaceConfigurationProvider()
+    {
+        return [
+            [true ],
+            [false]
+        ];
     }
 
     public function testGetLineContent()

--- a/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
+++ b/tests/JMS/PhpManipulator/Tests/TokenStreamTest.php
@@ -75,7 +75,7 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
         $this->setCode("<?php \n  echo     'foobar';\n        exit;");
         $i = 0;
         while ($this->stream->moveNext()) {
-            if( !$this->stream->token instanceof MarkerToken ) {
+            if( ! $this->stream->token instanceof MarkerToken) {
                 $this->assertEquals($lineIndentation[$i], strlen($this->stream->token->getLineIndentation()));
                 $this->assertEquals($indentation[$i]    , strlen($this->stream->token->getIndentation()));
                 $i++;


### PR DESCRIPTION
Solves the negative multiplier warning at str_repeat call (#8)
